### PR TITLE
Made Session.parse_url accept urls without versions as it should

### DIFF
--- a/openstack/session.py
+++ b/openstack/session.py
@@ -35,8 +35,8 @@ def parse_url(filt, url):
     path = result.path
     vstr = VERSION_PATTERN.search(path)
     if not vstr:
-        return (result.scheme + "://" + result.netloc + path.rstrip('/') +
-                '/' + filt.get_path())
+        path += '/' + filt.get_path()
+        vstr = VERSION_PATTERN.search(path)
     start, end = vstr.span()
     prefix = path[:start]
     version = '/' + filt.get_path(path[start + 1:end])


### PR DESCRIPTION
Fixed a clear bug. If catalog (supports multiple versions) returns endpoint without version, url path is stripped to empty string. In my opinion, the correct way to handle it is just to append the version, like in this patch.


OLD VERSION:
```
def parse_url(filt, url):
    print '**** parse_url ****'
    print 'arg filt:', filt
    print 'arg url:', url
    result = parse.urlparse(url)
    print 'result', result
    path = result.path
    print 'path', path
    vstr = VERSION_PATTERN.search(path)
    print 'vstr', vstr
    print result.scheme + "://" + result.netloc + "/" + filt.get_path()
    if not vstr:
        print 'not vstr!'
        print result.scheme + "://" + result.netloc + "/" + filt.get_path()
        print '-------------------'
        return result.scheme + "://" + result.netloc + "/" + filt.get_path()
    start, end = vstr.span()
    print 'start, end', start, end
    prefix = path[:start]
    print 'prefix', prefix
    version = '/' + filt.get_path(path[start + 1:end])
    print 'version', version
    postfix = path[end:].rstrip('/') if path[end:] else ''
    print 'postfix', postfix
    url = result.scheme + "://" + result.netloc + prefix + version + postfix
    print 'url', url
    print '-------------------'
    return url
```
output:
**** parse_url ****
arg filt: \<class 'openstack.network.network_service.NetworkService'\>
arg url: https://example.com/api/region1/neutron
result ParseResult(scheme=u'https', netloc=u'example.com', path=u'/api/region1/neutron', params='', query='', fragment='')
path /api/region1/neutron
vstr None
not vstr!
<p>
https://example.com/v2.0
</p>
---------------



NEW FIXED VERSION
```
def parse_url(filt, url):
    print '**** parse_url ****'
    print 'arg filt:', filt
    print 'arg url:', url
    result = parse.urlparse(url)
    print 'result', result
    path = result.path
    print 'path', path
    vstr = VERSION_PATTERN.search(path)
    print 'vstr', vstr
    print result.scheme + "://" + result.netloc + "/" + filt.get_path()
    if not vstr:
        print 'not vstr!'
        # return result.scheme + "://" + result.netloc + "/" + filt.get_path()
        path += '/' + filt.get_path()
        vstr = VERSION_PATTERN.search(path)
    start, end = vstr.span()
    print 'start, end', start, end
    prefix = path[:start]
    print 'prefix', prefix
    version = '/' + filt.get_path(path[start + 1:end])
    print 'version', version
    postfix = path[end:].rstrip('/') if path[end:] else ''
    print 'postfix', postfix
    url = result.scheme + "://" + result.netloc + prefix + version + postfix
    print 'url', url
    print '-------------------'
    return url
```

output:
**** parse_url ****
arg filt: \<class 'openstack.network.network_service.NetworkService'\>
arg url: https://example.com/api/region1/neutron
result ParseResult(scheme=u'https', netloc=u'example.com', path=u'/api/region1/neutron', params='', query='', fragment='')
path /api/region1/neutron
vstr None
https://example.com/v2.0
not vstr!
start, end 18 23
prefix /api/region1/neutron
version /v2.0
postfix
<p>url https://example.com/api/region1/neutron/v2.0</p>
-------------------